### PR TITLE
It is possible to end up without a mainModulePath on bad installs

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = {
   },
   require: function (pack) {
     var p = getPackagePath(pack);
-    if(p) return require(p.mainModulePath);
+    if(p && p.mainModulePath) return require(p.mainModulePath);
     console.log('Error: cannot find Atom package ' + pack);
   }
 }


### PR DESCRIPTION
see https://github.com/TypeStrong/atom-typescript/issues/162